### PR TITLE
Fix newrelic deprecation warning

### DIFF
--- a/lib/newrelic_faraday/instrumentation.rb
+++ b/lib/newrelic_faraday/instrumentation.rb
@@ -14,7 +14,7 @@ DependencyDetection.defer do
       def run_request_with_newrelic_trace(method, url, params, headers, &block)
         newrelic_host = parse_host_for_newrelic url
         metrics = ["External/#{newrelic_host}/Faraday::Connection/#{method}", "External/#{newrelic_host}/all", "External/all"]
-        if NewRelic::Agent::Instrumentation::MetricFrame.recording_web_transaction?
+        if NewRelic::Agent::Transaction.recording_web_transaction?
           metrics << "External/allWeb"
         else
           metrics << "External/allOther"


### PR DESCRIPTION
Fixes:

```
WARN : The method NewRelic::Agent::Instrumentation::MetricFrame.recording_web_transaction? is deprecated.
WARN : Please use NewRelic::Agent::Transaction.recording_web_transaction? instead.
```

It's deprecated at least for two years (checked `3.7.0.177` version)
