### PR TITLE
Add support for `faraday` 0.10.x

### DIFF
--- a/newrelic-faraday.gemspec
+++ b/newrelic-faraday.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(/^(test|spec|features)\//)
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday',      '>= 0.6', '< 0.10'
+  spec.add_dependency 'faraday',      '>= 0.6', '< 1.0.0'
   spec.add_dependency 'newrelic_rpm', '~> 3.0'
 
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
This relaxes the version constraint to allow support for `faraday` version 0.10.x which was recently released.